### PR TITLE
Hevc improvements

### DIFF
--- a/libavcodec/h264_slice.c
+++ b/libavcodec/h264_slice.c
@@ -822,10 +822,17 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
                 *fmt++ = AV_PIX_FMT_GBRP10;
             } else
                 *fmt++ = AV_PIX_FMT_YUV444P10;
-        } else if (CHROMA422(h))
+        } else if (CHROMA422(h)) {
+#if CONFIG_H264_V4L2REQUEST_HWACCEL
+            *fmt++ = AV_PIX_FMT_DRM_PRIME;
+#endif
             *fmt++ = AV_PIX_FMT_YUV422P10;
-        else
+        } else {
+#if CONFIG_H264_V4L2REQUEST_HWACCEL
+            *fmt++ = AV_PIX_FMT_DRM_PRIME;
+#endif
             *fmt++ = AV_PIX_FMT_YUV420P10;
+        }
         break;
     case 12:
         if (CHROMA444(h)) {
@@ -868,6 +875,9 @@ static enum AVPixelFormat get_pixel_format(H264Context *h, int force_callback)
             else
                 *fmt++ = AV_PIX_FMT_YUV444P;
         } else if (CHROMA422(h)) {
+#if CONFIG_H264_V4L2REQUEST_HWACCEL
+                *fmt++ = AV_PIX_FMT_DRM_PRIME;
+#endif
             if (h->avctx->color_range == AVCOL_RANGE_JPEG)
                 *fmt++ = AV_PIX_FMT_YUVJ422P;
             else

--- a/libavcodec/v4l2_request.c
+++ b/libavcodec/v4l2_request.c
@@ -30,6 +30,14 @@
 #include "internal.h"
 #include "v4l2_request.h"
 
+#ifndef DRM_FORMAT_NV15
+#define DRM_FORMAT_NV15 fourcc_code('N', 'V', '1', '5')
+#endif
+
+#ifndef DRM_FORMAT_NV20
+#define DRM_FORMAT_NV20 fourcc_code('N', 'V', '2', '0')
+#endif
+
 uint64_t ff_v4l2_request_get_capture_timestamp(AVFrame *frame)
 {
     V4L2RequestDescriptor *req = (V4L2RequestDescriptor*)frame->data[0];

--- a/libavcodec/v4l2_request.c
+++ b/libavcodec/v4l2_request.c
@@ -188,6 +188,13 @@ const uint32_t v4l2_request_capture_pixelformats[] = {
 #ifdef DRM_FORMAT_MOD_ALLWINNER_TILED
     V4L2_PIX_FMT_SUNXI_TILED_NV12,
 #endif
+#if defined(V4L2_PIX_FMT_NV15) && defined(DRM_FORMAT_NV15)
+    V4L2_PIX_FMT_NV15,
+#endif
+    V4L2_PIX_FMT_NV16,
+#if defined(V4L2_PIX_FMT_NV20) && defined(DRM_FORMAT_NV20)
+    V4L2_PIX_FMT_NV20,
+#endif
 };
 
 static int v4l2_request_set_drm_descriptor(V4L2RequestDescriptor *req, struct v4l2_format *format)
@@ -205,6 +212,22 @@ static int v4l2_request_set_drm_descriptor(V4L2RequestDescriptor *req, struct v4
     case V4L2_PIX_FMT_SUNXI_TILED_NV12:
         layer->format = DRM_FORMAT_NV12;
         desc->objects[0].format_modifier = DRM_FORMAT_MOD_ALLWINNER_TILED;
+        break;
+#endif
+#if defined(V4L2_PIX_FMT_NV15) && defined(DRM_FORMAT_NV15)
+    case V4L2_PIX_FMT_NV15:
+        layer->format = DRM_FORMAT_NV15;
+        desc->objects[0].format_modifier = DRM_FORMAT_MOD_LINEAR;
+        break;
+#endif
+    case V4L2_PIX_FMT_NV16:
+        layer->format = DRM_FORMAT_NV16;
+        desc->objects[0].format_modifier = DRM_FORMAT_MOD_LINEAR;
+        break;
+#if defined(V4L2_PIX_FMT_NV20) && defined(DRM_FORMAT_NV20)
+    case V4L2_PIX_FMT_NV20:
+        layer->format = DRM_FORMAT_NV20;
+        desc->objects[0].format_modifier = DRM_FORMAT_MOD_LINEAR;
         break;
 #endif
     default:

--- a/libavcodec/v4l2_request.c
+++ b/libavcodec/v4l2_request.c
@@ -442,7 +442,7 @@ static int v4l2_request_try_format(AVCodecContext *avctx, enum v4l2_buf_type typ
 
     while (ioctl(ctx->video_fd, VIDIOC_ENUM_FMT, &fmtdesc) >= 0) {
         if (fmtdesc.pixelformat == pixelformat)
-            return 0;
+            return v4l2_request_try_framesize(avctx, pixelformat);
 
         fmtdesc.index++;
     }

--- a/libavcodec/v4l2_request.c
+++ b/libavcodec/v4l2_request.c
@@ -22,6 +22,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h> // for close
 
 #include <sys/sysmacros.h>
 #include <libudev.h>
@@ -956,7 +958,7 @@ static void v4l2_request_frame_free(void *opaque, uint8_t *data)
     av_free(data);
 }
 
-static AVBufferRef *v4l2_request_frame_alloc(void *opaque, int size)
+static AVBufferRef *v4l2_request_frame_alloc(void *opaque, size_t size)
 {
     AVCodecContext *avctx = opaque;
     V4L2RequestContext *ctx = avctx->internal->hwaccel_priv_data;

--- a/libavcodec/v4l2_request.c
+++ b/libavcodec/v4l2_request.c
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdbool.h>
 #include <drm_fourcc.h>
 #include <linux/media.h>
 #include <sys/mman.h>
@@ -126,6 +127,29 @@ int ff_v4l2_request_query_control(AVCodecContext *avctx, struct v4l2_query_ext_c
     }
 
     return 0;
+}
+
+int ff_v4l2_request_query_control_size(AVCodecContext *avctx, unsigned int control_id,
+				       unsigned int *control_size)
+{
+    int ret;
+    V4L2RequestContext *ctx = avctx->internal->hwaccel_priv_data;
+
+    struct v4l2_query_ext_ctrl control = {
+        .id = control_id,
+    };
+
+    if (control_size)
+	    *control_size = 0;
+
+
+    ret = ioctl(ctx->video_fd, VIDIOC_QUERY_EXT_CTRL, control);
+    if (ret < 0)
+	    return false;
+
+    if (control_size)
+	    *control_size = control.elem_size;
+    return true;
 }
 
 int ff_v4l2_request_query_control_default_value(AVCodecContext *avctx, uint32_t id)

--- a/libavcodec/v4l2_request.h
+++ b/libavcodec/v4l2_request.h
@@ -62,6 +62,9 @@ int ff_v4l2_request_get_controls(AVCodecContext *avctx, struct v4l2_ext_control 
 
 int ff_v4l2_request_query_control(AVCodecContext *avctx, struct v4l2_query_ext_ctrl *control);
 
+int ff_v4l2_request_query_control_size(AVCodecContext *avctx, unsigned int control_id,
+				       unsigned int *control_size);
+
 int ff_v4l2_request_query_control_default_value(AVCodecContext *avctx, uint32_t id);
 
 int ff_v4l2_request_decode_slice(AVCodecContext *avctx, AVFrame *frame, struct v4l2_ext_control *control, int count, int first_slice, int last_slice);

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -458,7 +458,7 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
     V4L2RequestControlsHEVC *controls = h->ref->hwaccel_picture_private;
     struct v4l2_ctrl_hevc_slice_params *slice_params = controls->slice_params;
     V4L2RequestContextHEVC *ctx = avctx->internal->hwaccel_priv_data;
-    int num_controls = 4;
+    int num_controls = 3;
 
     struct v4l2_ext_control control[] = {
         {
@@ -477,9 +477,11 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
             .size = sizeof(controls->dec_params),
         },
         {
+        /* Reserve a slot for V4L2_CID_STATELESS_HEVC_SCALING_MATRIX
             .id = V4L2_CID_STATELESS_HEVC_SCALING_MATRIX,
             .ptr = &controls->scaling_matrix,
             .size = sizeof(controls->scaling_matrix),
+        */
         },
         {
         /* Reserve a slot for V4L2_CID_STATELESS_HEVC_SLICE_PARAMS
@@ -497,6 +499,12 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
         },
     };
 
+    if (ctx->support_scaling_matrix) {
+		control[num_controls].id = V4L2_CID_STATELESS_HEVC_SCALING_MATRIX;
+		control[num_controls].ptr = &controls->scaling_matrix;
+		control[num_controls].size = sizeof(controls->scaling_matrix);
+		num_controls++;
+    }
     if (ctx->max_slices) {
         control[num_controls].id = V4L2_CID_STATELESS_HEVC_SLICE_PARAMS,
         control[num_controls].ptr = &controls->slice_params,

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -19,6 +19,7 @@
 #include "hevcdec.h"
 #include "hwconfig.h"
 #include "v4l2_request.h"
+#include "internal.h"
 
 #define MAX_SLICES 16
 

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -22,7 +22,7 @@
 #include "v4l2_request.h"
 #include "internal.h"
 
-#define MAX_SLICES 16
+#define MAX_SLICES 600
 
 typedef struct V4L2RequestControlsHEVC {
     struct v4l2_ctrl_hevc_sps sps;

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -230,6 +230,15 @@ static void v4l2_request_hevc_fill_slice_params(const HEVCContext *h,
     }
 
     v4l2_request_hevc_fill_pred_table(h, &slice_params->pred_weight_table);
+
+    slice_params->num_entry_point_offsets = sh->num_entry_point_offsets;
+    if (slice_params->num_entry_point_offsets > 256) {
+        slice_params->num_entry_point_offsets = 256;
+        av_log(NULL, AV_LOG_ERROR, "%s: Currently only 256 entry points are supported, but slice has %d entry points.\n", __func__, sh->num_entry_point_offsets);
+    }
+
+    for (i = 0; i < slice_params->num_entry_point_offsets; i++)
+        slice_params->entry_point_offset_minus1[i] = sh->entry_point_offset[i] - 1;
 }
 
 static void fill_sps(struct v4l2_ctrl_hevc_sps *ctrl, const HEVCContext *h)

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -505,7 +505,7 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
 		control[num_controls].size = sizeof(controls->scaling_matrix);
 		num_controls++;
     }
-    if (ctx->max_slices) {
+    if (!is_frame_based(ctx) && controls->num_slices) {
         control[num_controls].id = V4L2_CID_STATELESS_HEVC_SLICE_PARAMS,
         control[num_controls].ptr = &controls->slice_params,
         control[num_controls].size = sizeof(controls->slice_params[0]) * controls->num_slices,

--- a/libavcodec/v4l2_request_hevc.c
+++ b/libavcodec/v4l2_request_hevc.c
@@ -511,11 +511,11 @@ static int v4l2_request_hevc_queue_decode(AVCodecContext *avctx, int last_slice)
         control[num_controls].size = sizeof(controls->slice_params[0]) * controls->num_slices,
         num_controls++;
 
-	/* add entry points offsets control if entry points are present */
-        if (slice_params->num_entry_point_offsets) {
-            control[num_controls].id = V4L2_CID_STATELESS_HEVC_ENTRY_POINT_OFFSETS,
-            control[num_controls].ptr = controls->entry_point_offsets,
-            control[num_controls].size = sizeof(*controls->entry_point_offsets) * slice_params->num_entry_point_offsets,
+        /* add entry points offsets control if entry points are present and supported by the driver */
+        if (ctx->support_entry_point_offsets && slice_params->num_entry_point_offsets) {
+            control[num_controls].id = V4L2_CID_STATELESS_HEVC_ENTRY_POINT_OFFSETS;
+            control[num_controls].ptr = controls->entry_point_offsets;
+            control[num_controls].size = sizeof(*controls->entry_point_offsets) * slice_params->num_entry_point_offsets;
             num_controls++;
         }
     }

--- a/libavdevice/Makefile
+++ b/libavdevice/Makefile
@@ -33,6 +33,7 @@ OBJS-$(CONFIG_GDIGRAB_INDEV)             += gdigrab.o
 OBJS-$(CONFIG_IEC61883_INDEV)            += iec61883.o
 OBJS-$(CONFIG_JACK_INDEV)                += jack.o timefilter.o
 OBJS-$(CONFIG_KMSGRAB_INDEV)             += kmsgrab.o
+OBJS-$(CONFIG_KMS_OUTDEV)                += kms_enc.o
 OBJS-$(CONFIG_LAVFI_INDEV)               += lavfi.o
 OBJS-$(CONFIG_OPENAL_INDEV)              += openal-dec.o
 OBJS-$(CONFIG_OPENGL_OUTDEV)             += opengl_enc.o

--- a/libavdevice/alldevices.c
+++ b/libavdevice/alldevices.c
@@ -38,6 +38,7 @@ extern const AVInputFormat  ff_gdigrab_demuxer;
 extern const AVInputFormat  ff_iec61883_demuxer;
 extern const AVInputFormat  ff_jack_demuxer;
 extern const AVInputFormat  ff_kmsgrab_demuxer;
+extern const AVOutputFormat ff_kms_muxer;
 extern const AVInputFormat  ff_lavfi_demuxer;
 extern const AVInputFormat  ff_openal_demuxer;
 extern const AVOutputFormat ff_opengl_muxer;

--- a/libavdevice/kms_enc.c
+++ b/libavdevice/kms_enc.c
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) 2013 Jeff Moguillansky
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * XVideo output device
+ *
+ * TODO:
+ * - add support to more formats
+ */
+
+#include "libavutil/opt.h"
+#include "libavutil/avassert.h"
+#include "libavutil/pixdesc.h"
+#include "libavutil/imgutils.h"
+#include "libavutil/hwcontext_drm.h"
+#include "libavformat/internal.h"
+#include "libavformat/mux.h"
+#include "avdevice.h"
+
+#include <stdatomic.h>
+
+#include "drm_fourcc.h"
+#include <drm.h>
+#include <drm_mode.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#define DRM_MODULE "sun4i-drm"
+
+#define ERRSTR strerror(errno)
+
+struct drm_setup {
+   int conId;
+   uint32_t crtcId;
+   int crtcIdx;
+   uint32_t planeId;
+   unsigned int out_fourcc;
+   struct {
+       int x, y, width, height;
+   } compose;
+};
+
+typedef struct drm_display_env_s
+{
+    AVClass *class;
+
+    int drm_fd;
+    uint32_t con_id;
+    struct drm_setup setup;
+    enum AVPixelFormat avfmt;
+
+} drm_display_env_t;
+
+static inline int av_frame_cropped_width(const AVFrame * const frame)
+{
+	return frame->width - (frame->crop_left + frame->crop_right);
+}
+
+static inline int av_frame_cropped_height(const AVFrame * const frame)
+{
+	return frame->height - (frame->crop_top + frame->crop_bottom);
+}
+
+static int xv_write_trailer(AVFormatContext *s)
+{
+    return 0;
+}
+
+static int xv_write_header(AVFormatContext *s)
+{
+    const AVCodecParameters * const par = s->streams[0]->codecpar;
+
+    if (   s->nb_streams > 1
+        || par->codec_type != AVMEDIA_TYPE_VIDEO
+        || par->codec_id   != AV_CODEC_ID_WRAPPED_AVFRAME) {
+        av_log(s, AV_LOG_ERROR, "Only supports one wrapped avframe stream\n");
+        return AVERROR(EINVAL);
+    }
+
+    // **********************
+
+    return 0;
+}
+
+typedef struct drm_aux_s {
+    uint32_t bo_handles[4];
+    unsigned int fb_handle;
+} drm_aux_t;
+
+static int xv_write_packet(AVFormatContext *s, AVPacket *pkt)
+{
+    AVFrame * const frame = (AVFrame *)pkt->data;
+    drm_display_env_t * const de = s->priv_data;
+
+    if (frame->format != AV_PIX_FMT_DRM_PRIME) {
+        av_log(s, AV_LOG_WARNING, "Frame (format=%d) not DRM_PRiME\n", frame->format);
+        return AVERROR(EINVAL);
+    }
+
+    {
+        const AVDRMFrameDescriptor *desc = (AVDRMFrameDescriptor*)frame->data[0];
+        AVBufferRef ** const pDrmBuf = frame->buf + 3;  // ** Abuse of this buf
+        drm_aux_t * da;
+
+        // * This is an abuse of this field - but just for now
+        // *** The intent was that we would only need to do this once for every
+        // buffer but this doesn't dig back far enough to get the original AVFrame
+        // so it is null every time :-(
+        if (*pDrmBuf == NULL) {
+            uint32_t pitches[4] = {0};
+            uint32_t offsets[4] = {0};
+            uint64_t modifiers[4] = {0};
+            uint32_t bo_plane_handles[4] = {0};
+            int i, j, n;
+
+            *pDrmBuf = av_buffer_allocz(sizeof(drm_aux_t));
+            da = (drm_aux_t *)((*pDrmBuf)->data);
+
+            for (i = 0; i < desc->nb_objects; ++i) {
+                if (drmPrimeFDToHandle(de->drm_fd, desc->objects[i].fd, da->bo_handles + i) != 0) {
+                    av_log(s, AV_LOG_WARNING, "drmPrimeFDToHandle failed: %s\n", ERRSTR);
+                    return -1;
+                }
+            }
+
+            n = 0;
+            for (i = 0; i < desc->nb_layers; ++i) {
+                for (j = 0; j < desc->layers[i].nb_planes; ++j) {
+                    const AVDRMPlaneDescriptor * const p = desc->layers[i].planes + j;
+                    const AVDRMObjectDescriptor * const obj = desc->objects + p->object_index;
+                    pitches[n] = p->pitch;
+                    offsets[n] = p->offset;
+                    modifiers[n] = obj->format_modifier;
+                    bo_plane_handles[n] = da->bo_handles[p->object_index];
+                    ++n;
+                }
+            }
+
+#if 0
+            av_log(s, AV_LOG_INFO, "%dx%d, fmt: %x, boh=%d,%d,%d,%d, pitch=%d,%d,%d,%d,"
+                   " offset=%d,%d,%d,%d, mod=%llx,%llx,%llx,%llx\n",
+                   av_frame_cropped_width(frame),
+                   av_frame_cropped_height(frame),
+                   desc->layers[0].format,
+                   bo_plane_handles[0],
+                   bo_plane_handles[1],
+                   bo_plane_handles[2],
+                   bo_plane_handles[3],
+                   pitches[0],
+                   pitches[1],
+                   pitches[2],
+                   pitches[3],
+                   offsets[0],
+                   offsets[1],
+                   offsets[2],
+                   offsets[3],
+                   (long long)modifiers[0],
+                   (long long)modifiers[1],
+                   (long long)modifiers[2],
+                   (long long)modifiers[3]
+                   );
+#endif
+
+            if (drmModeAddFB2WithModifiers(de->drm_fd,
+                                             av_frame_cropped_width(frame),
+                                             av_frame_cropped_height(frame),
+                                             desc->layers[0].format, bo_plane_handles,
+                                             pitches, offsets, modifiers,
+                                             &da->fb_handle, 0 /** 0 if no mods */) != 0) {
+                av_log(s, AV_LOG_WARNING, "drmModeAddFB2WithModifiers failed: %s\n", ERRSTR);
+                return -1;
+            }
+        }
+        da = (drm_aux_t *)((*pDrmBuf)->data);
+
+        int ret = drmModeSetPlane(de->drm_fd, de->setup.planeId, de->setup.crtcId,
+                                  da->fb_handle, 0,
+                    de->setup.compose.x, de->setup.compose.y,
+                    de->setup.compose.width,
+                    de->setup.compose.height,
+                    0, 0,
+                    av_frame_cropped_width(frame) << 16,
+                    av_frame_cropped_height(frame) << 16);
+
+        if (ret != 0) {
+            av_log(s, AV_LOG_WARNING, "drmModeSetPlane failed: %s\n", ERRSTR);
+        }
+    }
+
+    return 0;
+}
+
+static int xv_write_frame(AVFormatContext *s, int stream_index, AVFrame **ppframe,
+                          unsigned flags)
+{
+    /* xv_write_header() should have accepted only supported formats */
+    if ((flags & AV_WRITE_UNCODED_FRAME_QUERY))
+        return 0;
+
+    return 0;
+}
+
+static int xv_control_message(AVFormatContext *s, int type, void *data, size_t data_size)
+{
+    switch(type) {
+    case AV_APP_TO_DEV_WINDOW_REPAINT:
+        return 0;
+    default:
+        break;
+    }
+    return AVERROR(ENOSYS);
+}
+
+static int find_crtc(struct AVFormatContext * const avctx, int drmfd, struct drm_setup *s, uint32_t * const pConId)
+{
+   int ret = -1;
+   int i;
+   drmModeRes *res = drmModeGetResources(drmfd);
+   drmModeConnector *c;
+
+   if(!res)
+   {
+      printf( "drmModeGetResources failed: %s\n", ERRSTR);
+      return -1;
+   }
+
+   if (res->count_crtcs <= 0)
+   {
+      printf( "drm: no crts\n");
+      goto fail_res;
+   }
+
+   if (!s->conId) {
+      fprintf(stderr,
+         "No connector ID specified.  Choosing default from list:\n");
+
+      for (i = 0; i < res->count_connectors; i++) {
+         drmModeConnector *con =
+            drmModeGetConnector(drmfd, res->connectors[i]);
+         drmModeEncoder *enc = NULL;
+         drmModeCrtc *crtc = NULL;
+
+         if (con->encoder_id) {
+            enc = drmModeGetEncoder(drmfd, con->encoder_id);
+            if (enc->crtc_id) {
+               crtc = drmModeGetCrtc(drmfd, enc->crtc_id);
+            }
+         }
+
+         if (!s->conId && crtc) {
+            s->conId = con->connector_id;
+            s->crtcId = crtc->crtc_id;
+         }
+
+         av_log(avctx, AV_LOG_INFO, "Connector %d (crtc %d): type %d, %dx%d%s\n",
+                con->connector_id,
+                crtc ? crtc->crtc_id : 0,
+                con->connector_type,
+                crtc ? crtc->width : 0,
+                crtc ? crtc->height : 0,
+                (s->conId == (int)con->connector_id ?
+            " (chosen)" : ""));
+      }
+
+      if (!s->conId) {
+         av_log(avctx, AV_LOG_ERROR,
+            "No suitable enabled connector found.\n");
+         return -1;;
+      }
+   }
+
+   s->crtcIdx = -1;
+
+   for (i = 0; i < res->count_crtcs; ++i) {
+      if (s->crtcId == res->crtcs[i]) {
+         s->crtcIdx = i;
+         break;
+      }
+   }
+
+   if (s->crtcIdx == -1)
+   {
+       av_log(avctx, AV_LOG_WARNING, "drm: CRTC %u not found\n", s->crtcId);
+       goto fail_res;
+   }
+
+   if (res->count_connectors <= 0)
+   {
+       av_log(avctx, AV_LOG_WARNING, "drm: no connectors\n");
+       goto fail_res;
+   }
+
+   c = drmModeGetConnector(drmfd, s->conId);
+   if (!c)
+   {
+       av_log(avctx, AV_LOG_WARNING, "drmModeGetConnector failed: %s\n", ERRSTR);
+       goto fail_res;
+   }
+
+   if (!c->count_modes)
+   {
+       av_log(avctx, AV_LOG_WARNING, "connector supports no mode\n");
+       goto fail_conn;
+   }
+
+   {
+      drmModeCrtc *crtc = drmModeGetCrtc(drmfd, s->crtcId);
+      s->compose.x = crtc->x;
+      s->compose.y = crtc->y;
+      s->compose.width = crtc->width;
+      s->compose.height = crtc->height;
+      drmModeFreeCrtc(crtc);
+   }
+
+   if (pConId)
+      *pConId = c->connector_id;
+   ret = 0;
+
+fail_conn:
+   drmModeFreeConnector(c);
+
+fail_res:
+   drmModeFreeResources(res);
+
+   return ret;
+}
+
+static int find_plane(struct AVFormatContext * const avctx, int drmfd, struct drm_setup *s)
+{
+   drmModePlaneResPtr planes;
+   drmModePlanePtr plane;
+   unsigned int i;
+   unsigned int j;
+   int ret = 0;
+
+   planes = drmModeGetPlaneResources(drmfd);
+   if (!planes)
+   {
+       av_log(avctx, AV_LOG_WARNING, "drmModeGetPlaneResources failed: %s\n", ERRSTR);
+       return -1;
+   }
+
+   for (i = 0; i < planes->count_planes; ++i) {
+      plane = drmModeGetPlane(drmfd, planes->planes[i]);
+      if (!planes)
+      {
+          av_log(avctx, AV_LOG_WARNING, "drmModeGetPlane failed: %s\n", ERRSTR);
+          break;
+      }
+
+      if (!(plane->possible_crtcs & (1 << s->crtcIdx))) {
+         drmModeFreePlane(plane);
+         continue;
+      }
+
+      for (j = 0; j < plane->count_formats; ++j) {
+         if (plane->formats[j] == s->out_fourcc)
+            break;
+      }
+
+      if (j == plane->count_formats) {
+         drmModeFreePlane(plane);
+         continue;
+      }
+
+      s->planeId = plane->plane_id;
+      drmModeFreePlane(plane);
+      break;
+   }
+
+   if (i == planes->count_planes)
+      ret = -1;
+
+   drmModeFreePlaneResources(planes);
+   return ret;
+}
+
+// deinit is called if init fails so no need to clean up explicity here
+static int drm_vout_init(struct AVFormatContext * s)
+{
+    drm_display_env_t * const de = s->priv_data;
+
+    de->drm_fd = -1;
+    de->con_id = 0;
+    de->setup = (struct drm_setup){0};
+
+    de->setup.out_fourcc = DRM_FORMAT_NV12; // **** Need some sort of select
+
+    if ((de->drm_fd = drmOpen(DRM_MODULE, NULL)) < 0)
+    {
+        av_log(s, AV_LOG_ERROR, "Failed to drmOpen %s\n", DRM_MODULE);
+        return -1;
+    }
+
+    if (find_crtc(s, de->drm_fd, &de->setup, &de->con_id) != 0)
+    {
+        av_log(s, AV_LOG_ERROR, "failed to find valid mode\n");
+        return -1;
+    }
+
+    if (find_plane(s, de->drm_fd, &de->setup) != 0)
+    {
+        av_log(s, AV_LOG_ERROR, "failed to find compatible plane\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+static void drm_vout_deinit(struct AVFormatContext * s)
+{
+    drm_display_env_t * const de = s->priv_data;
+
+    if (de->drm_fd >= 0) {
+        close(de->drm_fd);
+        de->drm_fd = -1;
+    }
+
+}
+
+
+#define OFFSET(x) offsetof(drm_display_env_t, x)
+static const AVOption options[] = {
+#if 0
+    { "display_name", "set display name",       OFFSET(display_name), AV_OPT_TYPE_STRING, {.str = NULL }, 0, 0, AV_OPT_FLAG_ENCODING_PARAM },
+    { "window_id",    "set existing window id", OFFSET(window_id),    AV_OPT_TYPE_INT64,  {.i64 = 0 }, 0, INT64_MAX, AV_OPT_FLAG_ENCODING_PARAM },
+    { "window_size",  "set window forced size", OFFSET(window_width), AV_OPT_TYPE_IMAGE_SIZE, {.str = NULL}, 0, 0, AV_OPT_FLAG_ENCODING_PARAM },
+    { "window_title", "set window title",       OFFSET(window_title), AV_OPT_TYPE_STRING, {.str = NULL }, 0, 0, AV_OPT_FLAG_ENCODING_PARAM },
+    { "window_x",     "set window x offset",    OFFSET(window_x),     AV_OPT_TYPE_INT,    {.i64 = 0 }, -INT_MAX, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM },
+    { "window_y",     "set window y offset",    OFFSET(window_y),     AV_OPT_TYPE_INT,    {.i64 = 0 }, -INT_MAX, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM },
+#endif
+    { NULL }
+
+};
+
+static const AVClass xv_class = {
+    .class_name = "drm vid outdev",
+    .item_name  = av_default_item_name,
+    .option     = options,
+    .version    = LIBAVUTIL_VERSION_INT,
+    .category   = AV_CLASS_CATEGORY_DEVICE_VIDEO_OUTPUT,
+};
+
+AVOutputFormat ff_kms_muxer = {
+    .name           = "kms",
+    .long_name      = NULL_IF_CONFIG_SMALL("Drm video output device"),
+    .priv_data_size = sizeof(drm_display_env_t),
+    .audio_codec    = AV_CODEC_ID_NONE,
+    .video_codec    = AV_CODEC_ID_WRAPPED_AVFRAME,
+    .write_header   = xv_write_header,
+    .write_packet   = xv_write_packet,
+    .write_uncoded_frame = xv_write_frame,
+    .write_trailer  = xv_write_trailer,
+    .control_message = xv_control_message,
+    .flags          = AVFMT_NOFILE | AVFMT_VARIABLE_FPS | AVFMT_NOTIMESTAMPS,
+    .priv_class     = &xv_class,
+    .init           = drm_vout_init,
+    .deinit         = drm_vout_deinit,
+};

--- a/libavutil/hwcontext_drm.c
+++ b/libavutil/hwcontext_drm.c
@@ -53,6 +53,11 @@ static int drm_device_create(AVHWDeviceContext *hwdev, const char *device,
     AVDRMDeviceContext *hwctx = hwdev->hwctx;
     drmVersionPtr version;
 
+    if (device == NULL) {
+      hwctx->fd = -1;
+      return 0;
+    }
+
     hwctx->fd = open(device, O_RDWR);
     if (hwctx->fd < 0)
         return AVERROR(errno);


### PR DESCRIPTION
Tested on top of https://gitlab.collabora.com/sebastianfricke/linux/-/tree/brightsign_RKVDEC_HEVC

**HEVC:**
command:
`python3 fluster.py run -d FFmpeg-H.265-DRM -ts JCT-VC-HEVC_V1 -j1 -f csv -so /tmp/ffmpeg_hevc_tests.csv`
result: `Ran 122/147 tests successfully               in 278.389 secs`
(4 false positive tests)

**H264:**
command:
`python3 fluster.py run -d FFmpeg-H.264-DRM -ts JVT-AVC_V1 -j1 -f csv -so /tmp/ffmpeg_h264_tests.csv`
result: `Ran 118/135 tests successfully               in 84.151 secs`